### PR TITLE
feat: refresh zodiac grid and sticky header

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,7 +1,11 @@
 <template>
-  <header ref="headerEl" :class="headerClasses">
-    <nav class="container mx-auto px-4">
-      <div :class="pillClasses">
+  <header class="relative z-50 pt-6">
+    <nav
+      ref="navRef"
+      data-header-pill
+      class="sticky top-6 z-50 mx-auto w-[min(1200px,92%)] rounded-full bg-black/60 backdrop-blur px-6 py-4 transition-all motion-safe:duration-300 motion-reduce:transition-none data-[scrolled=true]:py-2 data-[scrolled=true]:ring-1 data-[scrolled=true]:ring-white/10 data-[scrolled=true]:shadow-md"
+    >
+      <div class="flex items-center justify-between gap-4">
         <a href="#hero" class="flex items-center gap-3 text-text-base focus-cosmic">
           <span class="sr-only">Cosmic home</span>
           <div class="relative flex h-10 w-10 items-center justify-center">
@@ -13,23 +17,21 @@
           <span class="font-heading text-xl font-bold">Cosmic</span>
         </a>
 
-        <div class="hidden items-center space-x-6 md:flex">
-          <NuxtLink
-            v-for="item in navItems"
-            :key="item.name"
-            class="relative group rounded-full px-4 py-2 text-sm font-medium text-text-muted transition-colors duration-200 ease-[var(--ease-cosmic)] hover:text-text-base focus-cosmic"
-            :class="{ 'text-text-base': activeSection === item.href }"
-            :to="item.href"
-            :aria-current="activeSection === item.href ? 'page' : undefined"
-            @click="handleNavSelect(item.href)"
-          >
-            <span>{{ item.name }}</span>
-            <span
-              class="pointer-events-none absolute -bottom-0.5 left-1/2 h-[2px] w-0 -translate-x-1/2 origin-center rounded-full bg-gradient-to-r from-violet via-magenta to-magenta opacity-0 shadow-[0_0_10px_rgba(168,85,247,0.5)] transition-all duration-300 ease-[var(--ease-cosmic)] group-hover:left-0 group-hover:w-full group-hover:translate-x-0 group-hover:opacity-100 group-focus-visible:left-0 group-focus-visible:w-full group-focus-visible:translate-x-0 group-focus-visible:opacity-100"
-              :class="{ 'left-0 w-full translate-x-0 opacity-100': activeSection === item.href }"
-            />
-          </NuxtLink>
-        </div>
+        <ul class="hidden flex-1 items-center justify-center gap-3 md:flex">
+          <li v-for="item in navItems" :key="item.name">
+            <NuxtLink
+              :to="item.href"
+              class="group relative px-4 py-2 text-sm font-medium text-slate-200 transition-colors motion-safe:transition-colors motion-safe:duration-300 hover:text-white focus-visible:outline-none focus-visible:rounded-full focus-visible:ring-2 focus-visible:ring-pink-500/60 after:content-[''] after:absolute after:left-3 after:right-3 after:-bottom-1 after:h-[2px] after:origin-left after:scale-x-0 after:rounded-full after:bg-gradient-to-r after:from-fuchsia-400 after:to-pink-500 motion-safe:after:transition-transform motion-safe:after:duration-300 group-hover:after:scale-x-100 focus-visible:after:scale-x-100"
+              :class="{
+                'text-white after:scale-x-100': activeSection === item.href,
+              }"
+              :aria-current="activeSection === item.href ? 'page' : undefined"
+              @click="handleNavSelect(item.href)"
+            >
+              {{ item.name }}
+            </NuxtLink>
+          </li>
+        </ul>
 
         <div class="hidden md:block">
           <a href="#readings" class="btn-cosmic text-sm">
@@ -39,24 +41,24 @@
 
         <button
           @click="toggleMenu"
-          class="md:hidden inline-flex h-10 w-10 items-center justify-center rounded-full glass-surface glass-hover focus-cosmic transition-transform duration-200 hover:scale-110"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/60 md:hidden"
           aria-label="Toggle menu"
         >
-          <component :is="isMenuOpen ? XIcon : MenuIcon" class="h-5 w-5 text-text-base" />
+          <component :is="isMenuOpen ? XIcon : MenuIcon" class="h-5 w-5" />
         </button>
       </div>
 
       <transition name="fade">
         <div
           v-if="isMenuOpen"
-          class="md:hidden mt-4 rounded-2xl glass-surface p-6 backdrop-blur-xl shadow-glass"
+          class="mt-4 rounded-2xl bg-black/70 p-6 text-text-base backdrop-blur md:hidden"
         >
           <nav class="space-y-4">
             <a
               v-for="item in navItems"
               :key="item.name"
               :href="item.href"
-              class="block rounded-lg px-4 py-3 text-text-base transition-colors duration-200 hover:bg-surface/60 hover:text-white focus-cosmic"
+              class="block rounded-lg px-4 py-3 text-slate-200 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/60"
               @click="handleNavSelect(item.href)"
             >
               {{ item.name }}
@@ -74,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { Menu as MenuIcon, Star, X as XIcon } from 'lucide-vue-next'
 
 const navItems = [
@@ -84,30 +86,21 @@ const navItems = [
   { name: 'About', href: '#about' },
 ]
 
-const headerEl = ref<HTMLElement | null>(null)
+const navRef = ref<HTMLElement | null>(null)
 const isMenuOpen = ref(false)
-const isScrolled = ref(false)
 const activeSection = ref<string | null>(null)
-let scrollHandler: (() => void) | null = null
 let sectionObserver: IntersectionObserver | null = null
-let resizeHandler: (() => void) | null = null
-
-const headerClasses = computed(() => [
-  'fixed inset-x-0 top-0 z-50 transition-[padding] duration-300 ease-[var(--ease-cosmic)]',
-  isScrolled.value ? 'py-3' : 'py-5',
-])
-
-const pillClasses = computed(() => [
-  'glass-hover flex items-center justify-between gap-4 rounded-full border border-white/10 px-6 transition-[padding,box-shadow,background-color,filter,ring-color] duration-300 ease-[var(--ease-cosmic)] backdrop-blur-xl supports-[backdrop-filter:none]:backdrop-blur-0 supports-[backdrop-filter:none]:bg-[color:hsl(var(--surface)/0.88)] ring-1 ring-transparent',
-  isScrolled.value
-    ? 'bg-[color:hsl(var(--surface)/0.72)] py-2 shadow-[0_18px_45px_rgba(14,16,26,0.32)] ring-white/5'
-    : 'bg-[color:hsl(var(--surface)/0.55)] py-4 shadow-none ring-transparent',
-])
+let resizeObserver: ResizeObserver | null = null
+let windowResizeHandler: (() => void) | null = null
 
 const setHeaderHeight = () => {
   if (typeof window === 'undefined') return
   requestAnimationFrame(() => {
-    const height = headerEl.value?.offsetHeight ?? 0
+    const nav = navRef.value
+    if (!nav) return
+    const styles = window.getComputedStyle(nav)
+    const topOffset = Number.parseFloat(styles.top ?? '0') || 0
+    const height = nav.offsetHeight + topOffset
     document.documentElement.style.setProperty('--header-height', `${height}px`)
   })
 }
@@ -136,17 +129,15 @@ watch(isMenuOpen, () => setHeaderHeight())
 onMounted(() => {
   if (typeof window === 'undefined') return
 
-  const onScroll = () => {
-    isScrolled.value = window.scrollY > 20
-    setHeaderHeight()
-  }
-  scrollHandler = onScroll
-  window.addEventListener('scroll', onScroll, { passive: true })
-  onScroll()
-
   setHeaderHeight()
-  resizeHandler = () => setHeaderHeight()
-  window.addEventListener('resize', resizeHandler)
+  const nav = navRef.value
+  if (typeof ResizeObserver !== 'undefined' && nav) {
+    resizeObserver = new ResizeObserver(() => setHeaderHeight())
+    resizeObserver.observe(nav)
+  }
+
+  windowResizeHandler = () => setHeaderHeight()
+  window.addEventListener('resize', windowResizeHandler)
 
   const initialHash = window.location.hash
   if (initialHash && navItems.some((item) => item.href === initialHash)) {
@@ -184,13 +175,11 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  if (scrollHandler) {
-    window.removeEventListener('scroll', scrollHandler)
-  }
-  if (resizeHandler) {
-    window.removeEventListener('resize', resizeHandler)
+  if (windowResizeHandler) {
+    window.removeEventListener('resize', windowResizeHandler)
   }
   sectionObserver?.disconnect()
+  resizeObserver?.disconnect()
   if (typeof window !== 'undefined') {
     document.documentElement.style.removeProperty('--header-height')
   }

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -3,7 +3,7 @@
     <nav
       ref="navRef"
       data-header-pill
-      class="sticky top-6 z-50 mx-auto w-[min(1200px,92%)] rounded-full bg-black/60 backdrop-blur px-6 py-4 transition-all motion-safe:duration-300 motion-reduce:transition-none data-[scrolled=true]:py-2 data-[scrolled=true]:ring-1 data-[scrolled=true]:ring-white/10 data-[scrolled=true]:shadow-md"
+      class="sticky top-6 z-50 mx-auto w-[min(1200px,92%)] rounded-full bg-black/60 backdrop-blur px-6 py-4 transition-all motion-safe:duration-300 motion-reduce:transition-none ring-0 shadow-none data-[scrolled=true]:py-2 data-[scrolled=true]:ring-1 data-[scrolled=true]:ring-white/10 data-[scrolled=true]:shadow-md"
     >
       <div class="flex items-center justify-between gap-4">
         <a href="#hero" class="flex items-center gap-3 text-text-base focus-cosmic">
@@ -21,7 +21,7 @@
           <li v-for="item in navItems" :key="item.name">
             <NuxtLink
               :to="item.href"
-              class="group relative px-4 py-2 text-sm font-medium text-slate-200 transition-colors motion-safe:transition-colors motion-safe:duration-300 hover:text-white focus-visible:outline-none focus-visible:rounded-full focus-visible:ring-2 focus-visible:ring-pink-500/60 after:content-[''] after:absolute after:left-3 after:right-3 after:-bottom-1 after:h-[2px] after:origin-left after:scale-x-0 after:rounded-full after:bg-gradient-to-r after:from-fuchsia-400 after:to-pink-500 motion-safe:after:transition-transform motion-safe:after:duration-300 group-hover:after:scale-x-100 focus-visible:after:scale-x-100"
+              class="group relative px-4 py-2 text-sm font-medium text-slate-200 transition-colors motion-safe:transition-colors motion-safe:duration-300 hover:text-white focus-visible:text-white focus-visible:outline-none focus-visible:rounded-full focus-visible:ring-2 focus-visible:ring-pink-500/60 after:content-[''] after:absolute after:left-3 after:right-3 after:-bottom-1 after:h-[2px] after:origin-left after:scale-x-0 after:rounded-full after:bg-gradient-to-r after:from-fuchsia-400 after:to-pink-500 motion-safe:after:transition-transform motion-safe:after:duration-300 group-hover:after:scale-x-100 focus-visible:after:scale-x-100"
               :class="{
                 'text-white after:scale-x-100': activeSection === item.href,
               }"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -51,11 +51,11 @@
       <DeckTeaser />
       <CompatibilityTeaser />
 
-      <section
-        id="zodiac"
-        class="py-24 px-4 scroll-mt-[calc(var(--header-height,0px)+1.5rem)]"
-      >
-        <div class="container mx-auto">
+      <section class="py-24 px-4">
+        <div
+          id="zodiac"
+          class="mx-auto w-[min(1200px,92%)] scroll-mt-[calc(var(--header-height,0px)+1.5rem)]"
+        >
           <SectionHeader
             subtitle="Your Cosmic Blueprint"
             title="Discover Your Zodiac Sign"
@@ -64,21 +64,29 @@
             titleGradient
           />
 
-          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            <CardGloss
+          <div
+            id="zodiac-grid"
+            class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-x-6 gap-y-8 xl:gap-x-7 xl:gap-y-9"
+          >
+            <a
               v-for="sign in zodiacSigns"
               :key="sign.name"
+              href="#readings"
               data-reveal
-              class="opacity-0 motion-reduce:opacity-100 [&>div]:p-5 [&>div]:lg:p-6"
+              class="group relative rounded-2xl bg-white/5 ring-1 ring-white/10 transition-all motion-safe:duration-300 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/60 hover:bg-white/10 hover:ring-pink-400/50 motion-safe:hover:scale-[1.02] opacity-0 motion-reduce:opacity-100"
               :style="{ animationFillMode: 'forwards' }"
             >
-              <div class="flex h-full flex-col items-center gap-5 text-center">
-                <div class="relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-violet via-magenta to-magenta/80 text-white shadow-[0_18px_38px_rgba(147,51,234,0.28)] transition-transform duration-500 ease-[var(--ease-cosmic)] group-hover:rotate-[8deg] group-hover:scale-110 motion-reduce:transform-none">
+              <span
+                class="pointer-events-none absolute inset-0 rounded-2xl before:absolute before:inset-0 before:rounded-2xl before:bg-gradient-to-r before:from-fuchsia-500/0 before:to-pink-500/0 before:transition-colors motion-safe:before:duration-300 group-hover:before:from-fuchsia-500/15 group-hover:before:to-pink-500/15"
+              />
+
+              <div class="relative flex h-full flex-col items-center gap-5 p-5 text-center">
+                <div class="relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-violet via-magenta to-magenta/80 text-white shadow-[0_18px_38px_rgba(147,51,234,0.28)] transition-transform motion-safe:duration-300 motion-reduce:transition-none motion-safe:group-hover:rotate-[8deg] motion-safe:group-hover:scale-110">
                   <component
                     :is="sign.Icon"
-                    class="h-7 w-7 transition-transform duration-500 group-hover:scale-110"
+                    class="h-7 w-7 transition-transform motion-safe:duration-300 motion-reduce:transition-none motion-safe:group-hover:scale-110"
                   />
-                  <span class="pointer-events-none absolute inset-0 bg-gradient-to-r from-white/10 via-transparent to-white/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+                  <span class="pointer-events-none absolute inset-0 bg-gradient-to-r from-white/10 via-transparent to-white/30 opacity-0 transition-opacity motion-safe:duration-300 motion-reduce:transition-none group-hover:opacity-100" />
                 </div>
                 <div class="space-y-2.5">
                   <h3 class="font-heading text-lg font-semibold text-text-base">{{ sign.name }}</h3>
@@ -86,7 +94,7 @@
                   <p class="text-sm leading-relaxed text-text-muted/90">{{ sign.description }}</p>
                 </div>
               </div>
-            </CardGloss>
+            </a>
           </div>
         </div>
       </section>
@@ -162,7 +170,6 @@ import AppHeader from '@/components/AppHeader.vue'
 import CompatibilityTeaser from '@/components/CompatibilityTeaser.vue'
 import DeckTeaser from '@/components/DeckTeaser.vue'
 import GlowCard from '@/components/GlowCard.vue'
-import CardGloss from '@/components/CardGloss.vue'
 import SectionHeader from '@/components/SectionHeader.vue'
 import ServicesCarousel from '@/components/ServicesCarousel.vue'
 import StarfieldCanvas from '@/components/StarfieldCanvas.vue'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,34 +66,36 @@
 
           <div
             id="zodiac-grid"
-            class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-x-6 gap-y-8 xl:gap-x-7 xl:gap-y-9"
+            class="grid [grid-template-columns:repeat(auto-fit,minmax(230px,1fr))] gap-x-6 gap-y-8 xl:gap-x-7 xl:gap-y-9"
           >
             <a
               v-for="sign in zodiacSigns"
               :key="sign.name"
               href="#readings"
               data-reveal
-              class="group relative rounded-2xl bg-white/5 ring-1 ring-white/10 transition-all motion-safe:duration-300 motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/60 hover:bg-white/10 hover:ring-pink-400/50 motion-safe:hover:scale-[1.02] opacity-0 motion-reduce:opacity-100"
+              class="group relative block rounded-2xl bg-white/5 ring-1 ring-white/10 transition-all motion-safe:duration-300 motion-reduce:transition-none hover:bg-white/10 hover:ring-pink-400/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/60 overflow-hidden opacity-0 motion-reduce:opacity-100"
               :style="{ animationFillMode: 'forwards' }"
             >
-              <span
-                class="pointer-events-none absolute inset-0 rounded-2xl before:absolute before:inset-0 before:rounded-2xl before:bg-gradient-to-r before:from-fuchsia-500/0 before:to-pink-500/0 before:transition-colors motion-safe:before:duration-300 group-hover:before:from-fuchsia-500/15 group-hover:before:to-pink-500/15"
-              />
-
-              <div class="relative flex h-full flex-col items-center gap-5 p-5 text-center">
-                <div class="relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-violet via-magenta to-magenta/80 text-white shadow-[0_18px_38px_rgba(147,51,234,0.28)] transition-transform motion-safe:duration-300 motion-reduce:transition-none motion-safe:group-hover:rotate-[8deg] motion-safe:group-hover:scale-110">
+              <div class="aspect-[8/3] p-5">
+                <div class="flex h-full flex-col items-center gap-5 text-center">
+                  <div class="relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-violet via-magenta to-magenta/80 text-white shadow-[0_18px_38px_rgba(147,51,234,0.28)] transition-transform motion-safe:duration-300 motion-reduce:transition-none motion-safe:group-hover:rotate-[8deg] motion-safe:group-hover:scale-110">
                   <component
                     :is="sign.Icon"
                     class="h-7 w-7 transition-transform motion-safe:duration-300 motion-reduce:transition-none motion-safe:group-hover:scale-110"
                   />
                   <span class="pointer-events-none absolute inset-0 bg-gradient-to-r from-white/10 via-transparent to-white/30 opacity-0 transition-opacity motion-safe:duration-300 motion-reduce:transition-none group-hover:opacity-100" />
-                </div>
-                <div class="space-y-2.5">
-                  <h3 class="font-heading text-lg font-semibold text-text-base">{{ sign.name }}</h3>
-                  <p class="text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-text-muted/60">{{ sign.dateRange }}</p>
-                  <p class="text-sm leading-relaxed text-text-muted/90">{{ sign.description }}</p>
+                  </div>
+                  <div class="space-y-2.5">
+                    <h3 class="font-heading text-lg font-semibold text-text-base">{{ sign.name }}</h3>
+                    <p class="text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-text-muted/60">{{ sign.dateRange }}</p>
+                    <p class="text-sm leading-relaxed text-text-muted/90">{{ sign.description }}</p>
+                  </div>
                 </div>
               </div>
+
+              <span
+                class="pointer-events-none absolute inset-y-0 -left-[140%] w-[60%] rounded-2xl bg-gradient-to-r from-white/0 via-white/20 to-white/0 transition-transform motion-safe:duration-700 motion-reduce:duration-0 group-hover:translate-x-[300%]"
+              />
             </a>
           </div>
         </div>

--- a/plugins/scroll-header.client.ts
+++ b/plugins/scroll-header.client.ts
@@ -1,0 +1,18 @@
+export default defineNuxtPlugin(() => {
+  const el = document.querySelector<HTMLElement>('[data-header-pill]')
+  if (!el) return
+
+  // Sentinel ~20px from top. When it leaves the viewport, we mark "scrolled".
+  const sentinel = document.createElement('div')
+  sentinel.style.position = 'absolute'
+  sentinel.style.top = '20px'
+  sentinel.style.width = '1px'
+  sentinel.style.height = '1px'
+  document.body.prepend(sentinel)
+
+  const io = new IntersectionObserver(([entry]) => {
+    el.toggleAttribute('data-scrolled', !entry.isIntersecting)
+  }, { root: null, threshold: 1 })
+
+  io.observe(sentinel)
+})

--- a/plugins/scroll-header.client.ts
+++ b/plugins/scroll-header.client.ts
@@ -1,6 +1,7 @@
 export default defineNuxtPlugin(() => {
   const el = document.querySelector<HTMLElement>('[data-header-pill]')
   if (!el) return
+  el.dataset.scrolled = 'false'
 
   // Sentinel ~20px from top. When it leaves the viewport, we mark "scrolled".
   const sentinel = document.createElement('div')
@@ -10,9 +11,12 @@ export default defineNuxtPlugin(() => {
   sentinel.style.height = '1px'
   document.body.prepend(sentinel)
 
-  const io = new IntersectionObserver(([entry]) => {
-    el.toggleAttribute('data-scrolled', !entry.isIntersecting)
-  }, { root: null, threshold: 1 })
+  const io = new IntersectionObserver(
+    ([entry]) => {
+      el.dataset.scrolled = entry?.isIntersecting ? 'false' : 'true'
+    },
+    { root: null, threshold: 1 },
+  )
 
   io.observe(sentinel)
 })


### PR DESCRIPTION
## Summary
- tighten the zodiac grid layout with a brighter hover glow and preserved accessibility states
- replace the header with a sticky pill navigation, gradient link underline, and scroll-aware styling via a client plugin

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68d919bc9c58832fb2cd71f612314bb9